### PR TITLE
Update Lothian endpoint to new URL

### DIFF
--- a/timetable-server-proxy
+++ b/timetable-server-proxy
@@ -11,7 +11,7 @@ def index():
 
 @app.route('/api/stop/<int:stop_id>')
 def proxy_stop(stop_id):
-    res = requests.get(f"https://tfeapp.com/api/website/stop_times.php?stop_id={stop_id}")
+    res = requests.get(f"https://lothianapi.co.uk/departureBoards/website?stops={stop_id}")
     return res.json()
 
 @app.route('/api/colors')


### PR DESCRIPTION
With the old Lothian Buses app closing down (;~;), they updated their endpoint URL. This broke the display, and updating the URL fixes it. Was tested on my machine using a symlink to `/home/pi/bus-timetable` but not on a real Pi.